### PR TITLE
Fix error with certs, that use legacy Common Name field

### DIFF
--- a/gemax/client_tls.go
+++ b/gemax/client_tls.go
@@ -8,12 +8,17 @@ import (
 // ErrInvalidServerName means that the server certificate doesn't match the server domain.
 var ErrInvalidServerName = errors.New("server domain and server TLS domain name don't match")
 
-func tlsVerifyDomain(cs *tls.ConnectionState, domain string) error {
+func tlsVerifyDomain(cs *tls.ConnectionState, domain string) (err error) {
 	for _, cert := range cs.PeerCertificates {
-		for _, name := range cert.DNSNames {
-			if name == domain {
-				return nil
-			}
+		// Workaround for "x509: certificate relies on legacy Common Name field, use SANs"
+		//
+		// Usually self-signed certs
+		if cert.Subject.CommonName == domain {
+			return nil
+		}
+		err = cert.VerifyHostname(domain)
+		if err == nil {
+			return nil
 		}
 	}
 	return ErrInvalidServerName


### PR DESCRIPTION
While testing this package, I was unable to connect to one Gemini server because it was using a self-signed certificate with a legacy Common Name Field.

Error: `connecting to the server "drewdevault.com:1965": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0`

Example server: `gemini://drewdevault.com`

----

_I don't know if this is a good solution btw!_